### PR TITLE
Fix FSDP distributed setup

### DIFF
--- a/RL2/workers/base.py
+++ b/RL2/workers/base.py
@@ -35,7 +35,7 @@ class Worker:
         else:
             self.device_mesh = dist.device_mesh.init_device_mesh(
                 "cuda",
-                mesh_dim_names=("fsdp"),
+                mesh_dim_names=("fsdp",),
                 mesh_shape=(dist.get_world_size(),)
             )
 


### PR DESCRIPTION
This PR fixes the following error I encountered when running `bash examples/orz_ppo.sh`.

```
Traceback (most recent call last):
  File "/root/RL2/RL2/trainer/ppo.py", line 126, in main
    trainer = PPOTrainer(config)
  File "/root/RL2/RL2/trainer/ppo.py", line 26, in __init__
    self.actor = Actor(config.actor, True)
  File "/root/RL2/RL2/workers/actor.py", line 15, in __init__
    super().__init__(config, train)
  File "/root/RL2/RL2/workers/base.py", line 37, in __init__
    self.device_mesh = dist.device_mesh.init_device_mesh(
  File "/root/miniconda3/envs/rl2/lib/python3.10/site-packages/torch/distributed/device_mesh.py", line 987, in init_device_mesh
    raise RuntimeError(
RuntimeError: ('mesh_shape and mesh_dim_names should have same length!', 'Found len(mesh_dim_names): 4 and len(mesh_shape):1.')
```

Co-authored-by: Ziyi Xu <2040703891@qq.com>