### PR TITLE
Update search-r1 regex

### DIFF
--- a/envs/searchr1.py
+++ b/envs/searchr1.py
@@ -5,7 +5,7 @@ import requests
 def interact(messages):
 
     match = re.search(
-        r"<search>(.*?)</search>", messages[-1]["content"]
+        r"<search>\s*(.*?)\s*</search>", messages[-1]["content"], re.DOTALL
     )
     if match is None:
         return []
@@ -41,7 +41,7 @@ def normalize_answer(s):
 def reward_fn(messages, answer):
 
     preds = re.findall(
-        r"<answer>(.*?)</answer>", messages[-1]["content"]
+        r"<answer>\s*(.*?)\s*</answer>", messages[-1]["content"], re.DOTALL
     )
     if len(preds) == 0:
         return False


### PR DESCRIPTION
### Summary

  - Suggested by #24, Updated regex patterns in envs/searchr1.py to handle whitespace and multiline content more flexibly
  - Added \s* around captured groups and re.DOTALL flag to both search and answer patterns

### Changes

  - Search pattern: <search>(.*?)</search> → <search>\s*(.*?)\s*</search> with re.DOTALL
  - Answer pattern: <answer>(.*?)</answer> → <answer>\s*(.*?)\s*</answer> with re.DOTALL

This improvement allows the patterns to correctly match content with leading/trailing whitespace or newlines, such
  as:
```
  <search>
  Who played harmonica on "I Feel for You" by Etta James?
  </search>
```