### PR TITLE
Add phase-one multi-agent PPO rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,151 @@ Diverge values may be used when needed.
 
 The function should be included in a Python script where the path is specified by `actor.rollout.env_path`.
 
+#### Multi-Agent PPO Environments
+
+RL2 also supports multi-agent episodes without changing the actor update path. In phase 1, all agents share the same actor policy and the rollout is flattened back into per-agent training samples before PPO updates.
+
+You may still provide a custom `generate(...)` function, but `env_path` can now also expose `reset(...)` and `step(...)` directly:
+
+```python
+async def reset(sample, tokenizer, extra_info, **kwargs) -> Dict:
+    return {
+        "agent_ids": ["planner", "solver"],
+        "current_agent": "planner",
+        "next_observations": {
+            "planner": "...",
+            "solver": "..."
+        },
+        "done_agents": [],
+        "shared_info": {},
+        "extra_info": extra_info
+    }
+
+async def step(
+    state: str,
+    action: str,
+    extra_info: Dict,
+    agent_id: str,
+    agent_states: Dict[str, str],
+    shared_info: Dict,
+    **kwargs
+) -> Dict:
+    return {
+        "current_agent": "solver",
+        "next_observations": {
+            "solver": "..."
+        },
+        "rewards": {
+            "planner": 0.0,
+            "solver": 1.0
+        },
+        "scores": {
+            "planner": 0.0,
+            "solver": 1.0
+        },
+        "done": False,
+        "done_agents": ["planner"],
+        "shared_info": {
+            "global_reward": 1.0,
+            "state_value_target": 1.0
+        },
+        "extra_info": extra_info
+    }
+```
+
+Multi-agent response fields:
+
+* `agent_ids`: all agent ids in the episode
+* `current_agent`: the next agent to act; if omitted and `rollout.multi_agent.agent_order=turn_based`, RL2 will select the next unfinished agent in order
+* `next_observations`: next prompt/message text for one or more agents
+* `rewards`: per-agent immediate rewards
+* `scores`: optional per-agent logging scores
+* `done_agents`: agents whose trajectories are complete
+* `shared_info`: shared episode state, team reward, or centralized critic targets
+* `extra_info`: passthrough metadata from the dataset / environment
+
+Relevant PPO config:
+
+```yaml
+rollout:
+  env_path: envs/multi_agent_countdown.py
+  multi_agent:
+    enabled: true
+    shared_policy: true
+    reward_mode: individual # `individual`, `team`, `mixed`
+    agent_order: turn_based # `turn_based`, `env_driven`
+
+critic:
+  use_centralized_value: false
+```
+
+See `envs/multi_agent_countdown.py` for a minimal shared-policy example.
+
+`envs/multi_agent_countdown.py` is compatible with:
+
+* the existing `Chenmien/Countdown` dataset fields (`prompt`, `numbers`, `target`)
+* local PPO-style data containing `prompt` plus `extra_info.answer`
+
+Minimal local JSON / JSONL example:
+
+```json
+[
+    {
+        "prompt": "Use 1, 3, 4, and 6 exactly once to make 24.",
+        "numbers": [1, 3, 4, 6],
+        "target": 24,
+        "extra_info": {
+            "answer": "(6 / (1 - 3 / 4))"
+        }
+    }
+]
+```
+
+One-click launch on a cluster:
+
+```bash
+bash examples/multi_agent_countdown_reinforce.sh
+```
+
+The script defaults to `Chenmien/Countdown`, and you can override paths / cluster settings without editing the file:
+
+```bash
+TRAIN_PATH="/path/to/train.jsonl" \
+TEST_PATH="/path/to/test.jsonl" \
+MODEL_NAME="Qwen/Qwen2.5-7B-Instruct" \
+NPROC_PER_NODE=8 \
+NNODES=2 \
+NODE_RANK=0 \
+MASTER_ADDR="10.0.0.1" \
+MASTER_PORT=29500 \
+EXPERIMENT_NAME="qwen2.5-7b_multi_agent_countdown" \
+bash examples/multi_agent_countdown_reinforce.sh
+```
+
+For SLURM clusters, you can submit the companion script directly:
+
+```bash
+sbatch examples/multi_agent_countdown_reinforce.slurm
+```
+
+Common SLURM overrides:
+
+```bash
+sbatch \
+  --nodes=2 \
+  --gres=gpu:8 \
+  --job-name=rl2-ma-countdown \
+  --export=ALL,TRAIN_PATH=/path/train.jsonl,TEST_PATH=/path/test.jsonl,MODEL_NAME=Qwen/Qwen2.5-7B-Instruct,EXPERIMENT_NAME=qwen2.5-7b_multi_agent_countdown \
+  examples/multi_agent_countdown_reinforce.slurm
+```
+
+The SLURM script derives:
+
+* `MASTER_ADDR` from the first hostname in `SLURM_JOB_NODELIST`
+* `NODE_RANK` from `SLURM_NODEID`
+* `NNODES` from `SLURM_NNODES`
+* `NPROC_PER_NODE` from `SLURM_GPUS_ON_NODE` unless you override it manually
+
 ### Launch [[Examples]](./examples)
 
 Use `torchrun` to launch the trainer. For example, for single node

--- a/RL2/datasets/__init__.py
+++ b/RL2/datasets/__init__.py
@@ -14,5 +14,6 @@ from .rl import (
     initialize_state_dict,
     add_llm_response,
     add_env_response,
-    base_generate
+    base_generate,
+    build_env_generate
 )

--- a/RL2/datasets/rl.py
+++ b/RL2/datasets/rl.py
@@ -1,53 +1,187 @@
-from typing import Dict, Any, List, Callable, Tuple
+from typing import Dict, Any, List, Callable, Tuple, Optional
 from omegaconf import OmegaConf, DictConfig
 import os
 import json
 import asyncio
+import inspect
 from enum import Enum
 from copy import deepcopy
 from collections import defaultdict
 from dataclasses import dataclass, field
+from itertools import count
 import torch
 from transformers import AutoTokenizer
 from RL2.datasets import get_tensor_dict, BaseDataset
 from RL2.utils.communication import async_request
 
 
+DEFAULT_AGENT_ID = "agent_0"
+EPISODE_COUNTER = count()
+PROMPT_GROUP_COUNTER = count()
+
+
+class SampleStatus(Enum):
+
+    RUNNING = "running"
+    ABORTED = "aborted"
+    DONE = "done"
+
+
+@dataclass
+class AgentTrajectory:
+
+    state_text: str = ""
+    action_text: str = ""
+    state_dict: Dict[str, List[int | float]] = field(default_factory=dict)
+    state_dicts: List[Dict[str, List[int | float]]] = field(default_factory=list)
+    turn: int = 0
+    metrics: Dict[str, List[float | int | bool]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    previous_action_text: str = ""
+    previous_response_length: int = 0
+    done: bool = False
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "state_text": self.state_text,
+            "action_text": self.action_text,
+            "state_dict": self.state_dict,
+            "state_dicts": self.state_dicts,
+            "turn": self.turn,
+            "metrics": dict(self.metrics),
+            "previous_action_text": self.previous_action_text,
+            "previous_response_length": self.previous_response_length,
+            "done": self.done
+        }
+
+
 @dataclass
 class Sample:
-
-    class Status(Enum):
-
-        RUNNING = "running"
-        ABORTED = "aborted"
-        DONE = "done"
+    Status = SampleStatus
 
     # for initialization
     sample: Dict[str, Any] = field(default_factory=dict)
-
-    # for environment interaction
-    state_text: str = ""
-    action_text: str = ""
-
-    # for training
-    state_dict: Dict[str, List[int | float]] = field(default_factory=dict)
-    state_dicts: List[Dict[str, List[int | float]]] = field(default_factory=list)
+    episode_id: int = field(default_factory=lambda: next(EPISODE_COUNTER))
+    prompt_group_id: int = 0
+    response_id: int = 0
+    multi_agent: bool = False
+    agent_ids: List[str] = field(default_factory=lambda: [DEFAULT_AGENT_ID])
+    current_agent: str = DEFAULT_AGENT_ID
+    shared_info: Dict[str, Any] = field(default_factory=dict)
+    metrics: Dict[str, List[float | int | bool]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    agents: Dict[str, AgentTrajectory] = field(default_factory=dict)
+    status: SampleStatus = SampleStatus.RUNNING
 
     # for logging
-    turn: int = 0
-    metrics: Dict[str, List[float | int | bool]] = field(default_factory=lambda: defaultdict(list))
-
-    # for partial rollout
-    status: Status = Status.RUNNING
-    previous_action_text: str = ""
-    previous_response_length: int = 0
+    def __post_init__(self):
+        self._ensure_agent(self.current_agent)
 
     def to_json(self) -> Dict[str, Any]:
+        return {
+            "sample": self.sample,
+            "episode_id": self.episode_id,
+            "prompt_group_id": self.prompt_group_id,
+            "response_id": self.response_id,
+            "multi_agent": self.multi_agent,
+            "agent_ids": self.agent_ids,
+            "current_agent": self.current_agent,
+            "shared_info": self.shared_info,
+            "metrics": dict(self.metrics),
+            "status": self.status.value,
+            "agents": {
+                agent_id: agent.to_json()
+                for agent_id, agent in self.agents.items()
+            }
+        }
 
-        data = self.__dict__
-        data["metrics"] = dict(self.metrics)
-        data["status"] = self.status.value
-        return data
+    def _ensure_agent(self, agent_id: str) -> AgentTrajectory:
+        if agent_id not in self.agents:
+            self.agents[agent_id] = AgentTrajectory()
+        return self.agents[agent_id]
+
+    @property
+    def agent_id(self) -> str:
+        return self.current_agent
+
+    @agent_id.setter
+    def agent_id(self, value: str):
+        self.current_agent = value
+        self._ensure_agent(value)
+
+    @property
+    def agent_done(self) -> bool:
+        return self._ensure_agent(self.current_agent).done
+
+    @agent_done.setter
+    def agent_done(self, value: bool):
+        self._ensure_agent(self.current_agent).done = value
+
+    @property
+    def active_agent(self) -> AgentTrajectory:
+        return self._ensure_agent(self.current_agent)
+
+    @property
+    def state_text(self) -> str:
+        return self.active_agent.state_text
+
+    @state_text.setter
+    def state_text(self, value: str):
+        self.active_agent.state_text = value
+
+    @property
+    def action_text(self) -> str:
+        return self.active_agent.action_text
+
+    @action_text.setter
+    def action_text(self, value: str):
+        self.active_agent.action_text = value
+
+    @property
+    def state_dict(self) -> Dict[str, List[int | float]]:
+        return self.active_agent.state_dict
+
+    @state_dict.setter
+    def state_dict(self, value: Dict[str, List[int | float]]):
+        self.active_agent.state_dict = value
+
+    @property
+    def state_dicts(self) -> List[Dict[str, List[int | float]]]:
+        return self.active_agent.state_dicts
+
+    @state_dicts.setter
+    def state_dicts(self, value: List[Dict[str, List[int | float]]]):
+        self.active_agent.state_dicts = value
+
+    @property
+    def turn(self) -> int:
+        return self.active_agent.turn
+
+    @turn.setter
+    def turn(self, value: int):
+        self.active_agent.turn = value
+
+    @property
+    def previous_action_text(self) -> str:
+        return self.active_agent.previous_action_text
+
+    @previous_action_text.setter
+    def previous_action_text(self, value: str):
+        self.active_agent.previous_action_text = value
+
+    @property
+    def previous_response_length(self) -> int:
+        return self.active_agent.previous_response_length
+
+    @previous_response_length.setter
+    def previous_response_length(self, value: int):
+        self.active_agent.previous_response_length = value
+
+    def use_agent(self, agent_id: str):
+        self.current_agent = agent_id
+        self._ensure_agent(agent_id)
 
 
 def initialize_state_dict(
@@ -87,37 +221,242 @@ def add_llm_response(sample: Sample, response: Dict[str, Any]):
     finish_reason = meta_info["finish_reason"]["type"]
     if finish_reason == "abort":
         # User may mask action tokens to avoid off-policy training
-        sample.status = Sample.Status.ABORTED
+        sample.status = SampleStatus.ABORTED
         sample.previous_action_text = sample.action_text
         sample.previous_response_length += meta_info["completion_tokens"]
         return
         
     sample.turn += 1
-    sample.metrics["response_length"].append(
+    response_length = (
         sample.previous_response_length + meta_info["completion_tokens"]
     )
+    sample.active_agent.metrics["response_length"].append(response_length)
+    sample.active_agent.metrics["length_clip_ratio"].append(
+        finish_reason == "length"
+    )
+    sample.metrics["response_length"].append(response_length)
     sample.metrics["length_clip_ratio"].append(finish_reason == "length")
+    sample.metrics[f"response_length/{sample.current_agent}"].append(
+        response_length
+    )
+    sample.metrics[f"length_clip_ratio/{sample.current_agent}"].append(
+        finish_reason == "length"
+    )
 
     # reset if not aborted
     sample.previous_action_text = ""
     sample.previous_response_length = 0
 
-def add_env_response(
+def _append_if_trainable(agent: AgentTrajectory):
+    if not agent.state_dict:
+        return
+    if sum(agent.state_dict.get("action_mask", [])) == 0 and len(agent.state_dicts) > 0:
+        return
+    agent.state_dicts.append(agent.state_dict)
+
+def _update_agent_observation(
+    tokenizer: AutoTokenizer,
+    agent: AgentTrajectory,
+    next_state: str,
+    prefix: str
+):
+    if next_state.startswith(prefix):
+        state_dict_delta = initialize_state_dict(
+            tokenizer,
+            next_state[len(prefix):]
+        )
+        for k, v in state_dict_delta.items():
+            agent.state_dict[k].extend(v)
+    else:
+        _append_if_trainable(agent)
+        agent.state_dict = initialize_state_dict(tokenizer, next_state)
+    agent.state_text = next_state
+    agent.action_text = ""
+
+def _finalize_agent(sample: Sample, agent_id: str):
+    agent = sample._ensure_agent(agent_id)
+    if agent.done:
+        return
+    _append_if_trainable(agent)
+    agent.done = True
+
+def _get_agent_episode_reward(agent: AgentTrajectory) -> float:
+    return float(sum([
+        state_dict["rewards"][-1]
+        for state_dict in agent.state_dicts
+        if len(state_dict["rewards"]) > 0
+    ]))
+
+def _collect_episode_metrics(sample: Sample):
+    if sample.metrics.get("_episode_metrics_collected"):
+        return
+
+    total_reward = float(sample.shared_info["global_reward"]) if "global_reward" in sample.shared_info else 0.0
+    total_turns = 0
+    total_score = 0.0
+    has_score = False
+    for agent_id in sample.agent_ids:
+        agent = sample._ensure_agent(agent_id)
+        reward = _get_agent_episode_reward(agent)
+        turns = agent.turn
+        score = float(sum(agent.metrics.get("scores", [])))
+
+        if "global_reward" not in sample.shared_info:
+            total_reward += reward
+        total_turns += turns
+        total_score += score
+        has_score = has_score or ("scores" in agent.metrics)
+
+        sample.metrics[f"rewards/{agent_id}"].append(reward)
+        sample.metrics[f"turns/{agent_id}"].append(turns)
+        sample.metrics[f"agent_done/{agent_id}"].append(agent.done)
+        if "scores" in agent.metrics:
+            sample.metrics[f"scores/{agent_id}"].append(score)
+
+    sample.metrics["turns"].append(total_turns)
+    sample.metrics["rewards"].append(total_reward)
+    if has_score:
+        sample.metrics["scores"].append(total_score)
+    sample.metrics["_episode_metrics_collected"] = [True]
+
+def _is_multi_agent_payload(response: Dict[str, Any]) -> bool:
+    return any(
+        key in response
+        for key in (
+            "agent_ids", "current_agent", "next_observations",
+            "done_agents", "shared_info", "rewards", "scores"
+        )
+    ) and isinstance(response.get("next_observations", {}), dict)
+
+def _normalize_multi_agent_response(
+    sample: Sample,
+    response: Dict[str, Any]
+) -> Dict[str, Any]:
+    rewards = response.get("rewards", {})
+    if isinstance(rewards, (int, float)):
+        rewards = {sample.current_agent: float(rewards)}
+    rewards = {str(k): float(v) for k, v in rewards.items()}
+
+    scores = response.get("scores", {})
+    if isinstance(scores, (int, float)):
+        scores = {sample.current_agent: float(scores)}
+    scores = {str(k): float(v) for k, v in scores.items()}
+
+    next_observations = response.get("next_observations", {})
+    if response.get("next_state") is not None:
+        next_observations = {
+            **next_observations,
+            sample.current_agent: response["next_state"]
+        }
+
+    done_agents = set(str(agent_id) for agent_id in response.get("done_agents", []))
+    if response.get("done", False):
+        done_agents.update(sample.agent_ids)
+    for agent_id, next_state in next_observations.items():
+        if next_state is None:
+            done_agents.add(str(agent_id))
+
+    return {
+        "agent_ids": [str(agent_id) for agent_id in response.get("agent_ids", sample.agent_ids)],
+        "current_agent": response.get("current_agent"),
+        "next_observations": {
+            str(agent_id): next_state
+            for agent_id, next_state in next_observations.items()
+            if next_state is not None
+        },
+        "rewards": rewards,
+        "scores": scores,
+        "done": response.get("done", False),
+        "done_agents": list(done_agents),
+        "shared_info": deepcopy(response.get("shared_info", sample.shared_info)),
+        "extra_info": deepcopy(response.get("extra_info", sample.sample.get("extra_info", {})))
+    }
+
+def _get_next_turn_agent(sample: Sample, requested_agent: Optional[str], agent_order: str) -> Optional[str]:
+    if requested_agent is not None and not sample._ensure_agent(requested_agent).done:
+        return requested_agent
+    available_agents = [
+        agent_id for agent_id in sample.agent_ids
+        if not sample._ensure_agent(agent_id).done
+    ]
+    if len(available_agents) == 0:
+        return None
+    if agent_order == "env_driven":
+        return available_agents[0]
+    if sample.current_agent in available_agents:
+        current_idx = available_agents.index(sample.current_agent)
+        return available_agents[(current_idx + 1) % len(available_agents)]
+    return available_agents[0]
+
+def _add_multi_agent_response(
+    config: DictConfig,
     tokenizer: AutoTokenizer,
     sample: Sample,
     response: Dict[str, Any]
 ):
+    response = _normalize_multi_agent_response(sample, response)
+    sample.multi_agent = True
+    sample.agent_ids = response["agent_ids"]
+    sample.shared_info = response["shared_info"]
+    sample.sample["extra_info"] = response["extra_info"]
+
+    current_agent_id = sample.current_agent
+    current_agent = sample._ensure_agent(current_agent_id)
+    current_agent.state_dict["rewards"][-1] = response["rewards"].get(
+        current_agent_id, 0.0
+    )
+    if current_agent_id in response["scores"]:
+        current_agent.metrics["scores"].append(response["scores"][current_agent_id])
+
+    for agent_id, score in response["scores"].items():
+        if agent_id == current_agent_id:
+            continue
+        sample._ensure_agent(agent_id).metrics["scores"].append(score)
+
+    previous_state = current_agent.state_text
+    previous_action = current_agent.action_text
+    for agent_id, next_state in response["next_observations"].items():
+        agent = sample._ensure_agent(agent_id)
+        prefix = previous_state + previous_action if agent_id == current_agent_id else agent.state_text
+        if not agent.state_dict:
+            agent.state_dict = initialize_state_dict(tokenizer, next_state)
+        else:
+            _update_agent_observation(tokenizer, agent, next_state, prefix)
+
+    for agent_id in response["done_agents"]:
+        _finalize_agent(sample, agent_id)
+
+    next_agent = _get_next_turn_agent(
+        sample,
+        response["current_agent"],
+        config.multi_agent.agent_order
+    )
+    if response["done"] or next_agent is None:
+        sample.status = SampleStatus.DONE
+        _collect_episode_metrics(sample)
+        return
+    sample.use_agent(next_agent)
+
+def add_env_response(
+    config: DictConfig,
+    tokenizer: AutoTokenizer,
+    sample: Sample,
+    response: Dict[str, Any]
+):
+    if _is_multi_agent_payload(response):
+        _add_multi_agent_response(config, tokenizer, sample, response)
+        return
 
     sample.state_dict["rewards"][-1] = response["reward"]
+    if "score" in response:
+        sample.active_agent.metrics["scores"].append(float(response["score"]))
 
     if response["done"]:
 
-        sample.status = Sample.Status.DONE
+        sample.status = SampleStatus.DONE
         sample.state_dicts.append(sample.state_dict)
-        sample.metrics["turns"].append(sample.turn)
-        sample.metrics["rewards"].append(
-            sum([state_dict["rewards"][-1] for state_dict in sample.state_dicts])
-        )
+        sample.active_agent.done = True
+        _collect_episode_metrics(sample)
         return
 
     if response["next_state"].startswith(sample.state_text + sample.action_text):
@@ -136,12 +475,139 @@ def add_env_response(
         )
     sample.state_text = response["next_state"]
 
+def _initialize_default_agent(
+    config: DictConfig,
+    tokenizer: AutoTokenizer,
+    sample: Sample
+):
+    sample.multi_agent = False
+    sample.agent_ids = [DEFAULT_AGENT_ID]
+    sample.use_agent(DEFAULT_AGENT_ID)
+    sample.shared_info = {}
+    if config.apply_chat_template:
+        sample.state_text = tokenizer.apply_chat_template(
+            sample.sample[config.messages_key],
+            add_generation_prompt=True,
+            tokenize=False
+        )
+    else:
+        sample.state_text = sample.sample[config.prompt_key]
+    sample.state_dict = initialize_state_dict(tokenizer, sample.state_text)
+
+def _normalize_initial_multi_agent_state(
+    config: DictConfig,
+    tokenizer: AutoTokenizer,
+    sample: Sample,
+    init_response: Dict[str, Any]
+):
+    if not _is_multi_agent_payload(init_response):
+        raise ValueError(
+            "Multi-agent environments must return `agent_ids` and "
+            "`next_observations` from `reset` or dataset sample."
+        )
+    response = _normalize_multi_agent_response(sample, init_response)
+    sample.multi_agent = True
+    sample.agent_ids = response["agent_ids"]
+    sample.shared_info = response["shared_info"]
+    sample.sample["extra_info"] = response["extra_info"]
+    for agent_id in sample.agent_ids:
+        sample.use_agent(agent_id)
+        next_state = response["next_observations"].get(agent_id)
+        if next_state is None:
+            sample.agent_done = True
+            continue
+        sample.state_text = next_state
+        sample.state_dict = initialize_state_dict(tokenizer, next_state)
+    next_agent = _get_next_turn_agent(
+        sample,
+        response["current_agent"],
+        config.multi_agent.agent_order
+    )
+    if next_agent is None or response["done"]:
+        sample.status = SampleStatus.DONE
+        _collect_episode_metrics(sample)
+        return
+    sample.use_agent(next_agent)
+
+async def _call_env_function(fn: Callable, **kwargs):
+    signature = inspect.signature(fn)
+    params = signature.parameters.values()
+    accepts_kwargs = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD
+        for param in params
+    )
+    if accepts_kwargs:
+        filtered_kwargs = kwargs
+    else:
+        filtered_kwargs = {
+            k: v for k, v in kwargs.items()
+            if k in signature.parameters
+        }
+    response = fn(**filtered_kwargs)
+    if inspect.isawaitable(response):
+        response = await response
+    return response
+
+def build_env_generate(
+    step_fn: Callable,
+    reset_fn: Optional[Callable] = None
+) -> Callable:
+    async def _env_step(sample: Sample) -> Dict[str, Any]:
+        return await _call_env_function(
+            step_fn,
+            sample=sample,
+            state=sample.state_text,
+            action=sample.action_text,
+            extra_info=deepcopy(sample.sample.get("extra_info", {})),
+            agent_id=sample.current_agent,
+            agent_states={
+                agent_id: sample._ensure_agent(agent_id).state_text
+                for agent_id in sample.agent_ids
+            },
+            shared_info=deepcopy(sample.shared_info),
+            episode_id=sample.episode_id
+        )
+
+    async def _env_reset(
+        config: DictConfig,
+        tokenizer: AutoTokenizer,
+        sample: Sample
+    ) -> Optional[Dict[str, Any]]:
+        if reset_fn is None:
+            return None
+        return await _call_env_function(
+            reset_fn,
+            sample=sample,
+            raw_sample=sample.sample,
+            config=config,
+            tokenizer=tokenizer,
+            extra_info=deepcopy(sample.sample.get("extra_info", {})),
+            episode_id=sample.episode_id
+        )
+
+    async def _generate(
+        config: DictConfig,
+        tokenizer: AutoTokenizer,
+        router_url: str,
+        sample: Sample
+    ):
+        return await base_generate(
+            config,
+            tokenizer,
+            router_url,
+            sample,
+            env_step_fn=_env_step,
+            env_reset_fn=_env_reset
+        )
+    return _generate
+
 async def base_generate(
     config: DictConfig,
     tokenizer: AutoTokenizer,
     router_url: str,
     sample: Sample,
-    env_step_fn: Callable
+    env_step_fn: Callable,
+    env_reset_fn: Optional[Callable] = None
 ):
     """
     A typical generate function where user only needs to provide the `env_step` 
@@ -151,32 +617,39 @@ async def base_generate(
 
     match sample.status:
 
-        case Sample.Status.RUNNING:
+        case SampleStatus.RUNNING:
 
-            # For Gym-like environments, `reset` function should be called to 
-            # obtain the initial state
-            if config.apply_chat_template:
-                # User may provide tools
-                sample.state_text = tokenizer.apply_chat_template(
-                    sample.sample[config.messages_key],
-                    add_generation_prompt=True,
-                    tokenize=False
+            if getattr(config, "multi_agent", None) and config.multi_agent.enabled:
+                init_response = None
+                if env_reset_fn is not None:
+                    init_response = await env_reset_fn(
+                        config, tokenizer, sample
+                    )
+                elif _is_multi_agent_payload(sample.sample):
+                    init_response = sample.sample
+                if init_response is None:
+                    raise ValueError(
+                        "Multi-agent rollout is enabled but the environment does "
+                        "not provide a `reset` function or dataset-level initial "
+                        "multi-agent observations."
+                    )
+                _normalize_initial_multi_agent_state(
+                    config, tokenizer, sample, init_response
                 )
             else:
-                sample.state_text = sample.sample[config.prompt_key]
+                _initialize_default_agent(config, tokenizer, sample)
 
-            sample.state_dict = initialize_state_dict(
-                tokenizer, sample.state_text
-            )
+        case SampleStatus.ABORTED:
+            sample.status = SampleStatus.RUNNING
 
-        case Sample.Status.ABORTED:
-            sample.status = Sample.Status.RUNNING
-
-        case Sample.Status.DONE:
+        case SampleStatus.DONE:
             # User may treat this case as `RUNNING` to avoid off-policy training
             return
 
     while True:
+        if sample.status == SampleStatus.DONE:
+            return
+
         # TODO: set `max_tokens`
         response = await async_request(
             router_url,
@@ -192,12 +665,12 @@ async def base_generate(
             }
         )
         add_llm_response(sample, response)
-        if sample.status == Sample.Status.ABORTED:
+        if sample.status == SampleStatus.ABORTED:
             return
         
         response = await env_step_fn(sample)
-        add_env_response(tokenizer, sample, response)
-        if sample.status == Sample.Status.DONE:
+        add_env_response(config, tokenizer, sample, response)
+        if sample.status == SampleStatus.DONE:
             return
 
 
@@ -212,9 +685,14 @@ class SampleGroup:
 
         self.config = config
         self.tokenizer = tokenizer
+        self.prompt_group_id = next(PROMPT_GROUP_COUNTER)
         self.samples = [
-            Sample(sample=deepcopy(sample))
-            for _ in range(config.responses_per_prompt)
+            Sample(
+                sample=deepcopy(sample),
+                prompt_group_id=self.prompt_group_id,
+                response_id=response_id
+            )
+            for response_id in range(config.responses_per_prompt)
         ]
 
     async def generate(self, router_url: str, generate_fn: Callable) -> "SampleGroup":
@@ -231,7 +709,12 @@ class SampleGroup:
 
         sample = self.samples[0]
         print("\n")
-        print(sample.state_text + sample.action_text)
+        if sample.multi_agent:
+            for agent_id in sample.agent_ids:
+                agent = sample._ensure_agent(agent_id)
+                print(f"[{agent_id}] {agent.state_text}{agent.action_text}")
+        else:
+            print(sample.state_text + sample.action_text)
         print("[Reward]", sample.metrics["rewards"][0])
 
     def save(self, step):
@@ -245,22 +728,76 @@ class SampleGroup:
         
         all_tensor_dicts, metrics = [], defaultdict(list)
         for sample in self.samples:
-            tensor_dicts = []
-            for state_dict in sample.state_dicts:
-                tensor_dict = get_tensor_dict(
-                    state_dict["states"],
-                    state_dict["actions"],
-                    state_dict["action_mask"],
+            team_reward = float(
+                sample.shared_info.get(
+                    "global_reward",
+                    sum(_get_agent_episode_reward(agent) for agent in sample.agents.values())
                 )
-                tensor_dict["llm_logps"] = torch.FloatTensor(
-                    state_dict["logps"][1:]
-                )
-                tensor_dict["rewards"] = torch.FloatTensor(
-                    state_dict["rewards"][1:]
-                )
-                tensor_dicts.append(tensor_dict)
-            all_tensor_dicts.append(tensor_dicts)
+            ) if sample.multi_agent else None
+            value_target = sample.shared_info.get("state_value_target")
+
+            for agent_idx, agent_id in enumerate(sample.agent_ids):
+                sample.use_agent(agent_id)
+                tensor_dicts = []
+                for state_dict in sample.state_dicts:
+                    if sum(state_dict["action_mask"][1:]) == 0:
+                        continue
+                    tensor_dict = get_tensor_dict(
+                        state_dict["states"],
+                        state_dict["actions"],
+                        state_dict["action_mask"],
+                    )
+                    seq_len = tensor_dict["states"].shape[0]
+                    tensor_dict["llm_logps"] = torch.FloatTensor(
+                        state_dict["logps"][1:]
+                    )
+                    tensor_dict["rewards"] = torch.FloatTensor(
+                        state_dict["rewards"][1:]
+                    )
+                    tensor_dict["agent_id"] = torch.full(
+                        (seq_len,), agent_idx, dtype=torch.long
+                    )
+                    tensor_dict["episode_id"] = torch.full(
+                        (seq_len,), sample.episode_id, dtype=torch.long
+                    )
+                    tensor_dict["adv_group_id"] = torch.full(
+                        (seq_len,),
+                        sample.prompt_group_id * 1024 + agent_idx,
+                        dtype=torch.long
+                    )
+                    tensor_dict["agent_done"] = torch.full(
+                        (seq_len,),
+                        int(sample.agent_done),
+                        dtype=torch.long
+                    )
+                    tensor_dict["shared_mask"] = torch.zeros(
+                        seq_len, dtype=torch.long
+                    )
+                    if sample.multi_agent:
+                        action_positions = torch.where(
+                            tensor_dict["action_mask"] > 0
+                        )[0]
+                        if len(action_positions) > 0:
+                            last_action = action_positions[-1]
+                            tensor_dict["shared_mask"][last_action] = 1
+                        if team_reward is not None:
+                            tensor_dict["team_rewards"] = torch.zeros(
+                                seq_len, dtype=torch.float32
+                            )
+                            if len(action_positions) > 0:
+                                tensor_dict["team_rewards"][last_action] = team_reward
+                        if value_target is not None:
+                            tensor_dict["state_value_targets"] = torch.zeros(
+                                seq_len, dtype=torch.float32
+                            )
+                            if len(action_positions) > 0:
+                                tensor_dict["state_value_targets"][last_action] = float(value_target)
+                    tensor_dicts.append(tensor_dict)
+                if len(tensor_dicts) > 0:
+                    all_tensor_dicts.append(tensor_dicts)
             for k, v in sample.metrics.items():
+                if k.startswith("_"):
+                    continue
                 metrics[k].extend(v)
         return all_tensor_dicts, metrics
 

--- a/RL2/trainer/config/ppo.yaml
+++ b/RL2/trainer/config/ppo.yaml
@@ -60,6 +60,11 @@ rollout:
   test_ratio: 0.03
   env_path: null
   bucket_size: 512
+  multi_agent:
+    enabled: false
+    shared_policy: true
+    reward_mode: individual # `individual`, `team` or `mixed`
+    agent_order: turn_based # `turn_based` or `env_driven`
 
 ref_actor:
   temperature: ${rollout.train.sampling_params.temperature}
@@ -70,6 +75,7 @@ critic:
   clip: 0.5
   avg_level: ${actor.avg_level}
   offload_model: ${actor.offload_model}
+  use_centralized_value: false
 
 adv:
   estimator: reinforce # `reinforce` or `gae`

--- a/RL2/utils/algorithms.py
+++ b/RL2/utils/algorithms.py
@@ -26,8 +26,19 @@ def compute_approx_kl(
         raise NotImplementedError
 
 def _compute_gae(
-    tensor_dict: Dict[str, torch.Tensor], gamma: float, lamda: float
+    tensor_dict: Dict[str, torch.Tensor],
+    gamma: float,
+    lamda: float,
+    use_centralized_value: bool = False
 ) -> Dict[str, torch.Tensor]:
+    if use_centralized_value and "state_value_targets" in tensor_dict:
+        returns = tensor_dict["state_value_targets"]
+        gaes = returns - tensor_dict["old_values"]
+        action_gaes = gaes[torch.where(tensor_dict["action_mask"])]
+        advantages = (gaes - action_gaes.mean()) * tensor_dict["action_mask"] / (
+            action_gaes.std() + torch.finfo(gaes.dtype).eps
+        )
+        return {"advantages": advantages, "returns": returns}
     
     # \delta_t = r_t + \gamma * V(s_{t+1}) - V(s_t)
     next_values = F.pad(tensor_dict["old_values"][:, 1:], (0, 1), value=0)
@@ -55,23 +66,59 @@ def _compute_reinforce_adv(
     norm_var: bool
 ) -> Dict[str, torch.Tensor]:
     
-    rewards = tensor_dict["rewards"].sum(-1).view(-1, responses_per_prompt)
+    rewards = tensor_dict["rewards"].sum(-1)
 
     if responses_per_prompt == 1 or global_norm:
         baseline = rewards.mean()
         std = rewards.std()
+        advantages = rewards - baseline
+        if norm_var:
+            advantages /= (
+                std + torch.finfo(advantages.dtype).eps
+            )
+    elif "adv_group_id" in tensor_dict:
+        group_ids = tensor_dict["adv_group_id"][:, 0]
+        advantages = torch.zeros_like(rewards)
+        for group_id in torch.unique(group_ids):
+            indices = group_ids == group_id
+            grouped_rewards = rewards[indices]
+            advantages[indices] = grouped_rewards - grouped_rewards.mean()
+            if norm_var:
+                advantages[indices] /= (
+                    grouped_rewards.std() +
+                    torch.finfo(advantages.dtype).eps
+                )
     else:
+        rewards = rewards.view(-1, responses_per_prompt)
         baseline = rewards.mean(-1, keepdim=True)
         std = rewards.std(-1, keepdim=True)
-
-    advantages = rewards - baseline
-    if norm_var:
-        advantages /= (
-            std + torch.finfo(advantages.dtype).eps
-        )
+        advantages = rewards - baseline
+        if norm_var:
+            advantages /= (
+                std + torch.finfo(advantages.dtype).eps
+            )
+        advantages = advantages.view(-1)
 
     advantages = advantages.view(-1, 1) * tensor_dict["action_mask"]
     return {"advantages": advantages}
+
+def _get_reward_tensor(
+    config: DictConfig,
+    tensor_dict: Dict[str, torch.Tensor]
+) -> torch.Tensor:
+    if not getattr(config.rollout, "multi_agent", None):
+        return tensor_dict["rewards"]
+    if not config.rollout.multi_agent.enabled:
+        return tensor_dict["rewards"]
+
+    reward_mode = config.rollout.multi_agent.reward_mode
+    if reward_mode == "individual":
+        return tensor_dict["rewards"]
+    if reward_mode == "team" and "team_rewards" in tensor_dict:
+        return tensor_dict["team_rewards"]
+    if reward_mode == "mixed" and "team_rewards" in tensor_dict:
+        return tensor_dict["rewards"] + tensor_dict["team_rewards"]
+    return tensor_dict["rewards"]
 
 @time_logger("compute_advantages")
 def compute_advantages(
@@ -117,7 +164,10 @@ def compute_advantages(
     processed_tensor_dict = pack_tensor_dicts([
         _extract_actions(
             {
-                k: v[start:end]
+                k: (
+                    _get_reward_tensor(config, tensor_dict)[start:end]
+                    if k == "rewards" else v[start:end]
+                )
                 for k, v in tensor_dict.items()
             }
         )
@@ -126,7 +176,10 @@ def compute_advantages(
 
     if config.adv.estimator == "gae":
         tensor_dict_delta = _compute_gae(
-            processed_tensor_dict, config.adv.gamma, config.adv.lamda
+            processed_tensor_dict,
+            config.adv.gamma,
+            config.adv.lamda,
+            config.critic.use_centralized_value
         )
     elif config.adv.estimator == "reinforce":
         tensor_dict_delta = _compute_reinforce_adv(

--- a/RL2/workers/rollout.py
+++ b/RL2/workers/rollout.py
@@ -18,7 +18,8 @@ from RL2.datasets import (
     get_dataloaders,
     pack_tensor_dicts,
     RLDataset,
-    SampleGroup
+    SampleGroup,
+    build_env_generate
 )
 from RL2.utils.communication import (
     get_host,
@@ -69,6 +70,9 @@ class Rollout:
     def __init__(self, config: DictConfig):
         
         self.config = config
+        if config.multi_agent.enabled:
+            assert config.multi_agent.shared_policy, \
+                "Phase-1 multi-agent rollout only supports shared_policy=true."
         self._prepare_device_mesh()
         self._prepare_environment_variables()
 
@@ -80,6 +84,8 @@ class Rollout:
             self.train_dataloader, self.test_dataloader = get_dataloaders(
                 RLDataset, config, self.tokenizer, 1
             )
+            self.train_dataloader.dataset.config.multi_agent = config.multi_agent
+            self.test_dataloader.dataset.config.multi_agent = config.multi_agent
 
             self._prepare_environment()
             self.sample_buffer: List[SampleGroup] = []
@@ -173,6 +179,18 @@ class Rollout:
         )
         self.env = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(self.env)
+        if hasattr(self.env, "generate"):
+            self.generate_fn = self.env.generate
+            return
+        if hasattr(self.env, "step"):
+            self.generate_fn = build_env_generate(
+                self.env.step,
+                getattr(self.env, "reset", None)
+            )
+            return
+        raise AttributeError(
+            "Custom environment must define `generate` or `step`."
+        )
 
     @time_logger("rollout")
     async def __call__(
@@ -189,7 +207,7 @@ class Rollout:
                 pendings.add(
                     asyncio.create_task(
                         sample_group.generate(
-                            self.router_url, self.env.generate
+                            self.router_url, self.generate_fn
                         )
                     )
                 )

--- a/envs/gem.py
+++ b/envs/gem.py
@@ -116,6 +116,6 @@ async def generate(
             return
         
         response = await env_step(tokenizer, sample)
-        add_env_response(tokenizer, sample, response)
+        add_env_response(config, tokenizer, sample, response)
         if sample.status == Sample.Status.DONE:
             return

--- a/envs/multi_agent_countdown.py
+++ b/envs/multi_agent_countdown.py
@@ -1,0 +1,143 @@
+from typing import Dict, Any
+import re
+
+PLANNER_ID = "planner"
+SOLVER_ID = "solver"
+
+
+def _get_question(sample: Dict[str, Any]) -> str:
+    if "prompt" in sample:
+        return sample["prompt"]
+    if "numbers" in sample and "target" in sample:
+        numbers = ", ".join(map(str, sample["numbers"]))
+        return (
+            f"Use the numbers [{numbers}] exactly once to make {sample['target']}. "
+            "Return a valid arithmetic expression."
+        )
+    raise KeyError(
+        "multi_agent_countdown expects either `prompt` or `numbers` + `target`."
+    )
+
+
+def _planner_prompt(question: str) -> str:
+    return (
+        f"Question: {question}\n"
+        "You are the planner agent. Think about the solution strategy and "
+        "share short notes for the solver. Do not output the final answer."
+    )
+
+
+def _solver_prompt(question: str) -> str:
+    return (
+        f"Question: {question}\n"
+        "You are the solver agent. Wait for the planner's notes, then give the "
+        "final arithmetic expression inside <answer></answer>."
+    )
+
+
+def _compute_countdown_reward(sample: Dict[str, Any], action: str) -> float:
+    match = re.search(r"<answer>(.*?)</answer>", action, re.DOTALL)
+    equation = match.group(1).strip() if match is not None else action.strip()
+
+    if "target" not in sample or "numbers" not in sample:
+        answer = str(
+            sample.get("extra_info", {}).get(
+                "answer",
+                sample.get("answer", "")
+            )
+        ).strip()
+        return float(equation == answer)
+
+    reward = 0.1
+    try:
+        numbers = [int(n) for n in re.findall(r"\d+", equation)]
+        assert sorted(numbers) == sorted(sample["numbers"])
+    except Exception:
+        return 0.0
+
+    try:
+        assert re.match(r"^[\d+\-*/().\s]+$", equation)
+        result = eval(equation, {"__builtins__": None}, {})
+        assert abs(result - sample["target"]) < 1e-5
+        reward = 1.0
+    except Exception:
+        pass
+    return reward
+
+
+async def reset(sample, tokenizer, extra_info, **kwargs) -> Dict[str, Any]:
+    question = _get_question(sample.sample)
+    return {
+        "agent_ids": [PLANNER_ID, SOLVER_ID],
+        "current_agent": PLANNER_ID,
+        "next_observations": {
+            PLANNER_ID: tokenizer.apply_chat_template(
+                [{"role": "user", "content": _planner_prompt(question)}],
+                add_generation_prompt=True,
+                tokenize=False
+            ),
+            SOLVER_ID: tokenizer.apply_chat_template(
+                [{"role": "user", "content": _solver_prompt(question)}],
+                add_generation_prompt=True,
+                tokenize=False
+            )
+        },
+        "rewards": {PLANNER_ID: 0.0, SOLVER_ID: 0.0},
+        "done": False,
+        "done_agents": [],
+        "shared_info": {},
+        "extra_info": extra_info
+    }
+
+
+async def step(
+    state: str,
+    action: str,
+    extra_info: Dict[str, Any],
+    agent_id: str,
+    agent_states: Dict[str, str],
+    shared_info: Dict[str, Any],
+    **kwargs
+) -> Dict[str, Any]:
+    if agent_id == PLANNER_ID:
+        solver_state = (
+            agent_states[SOLVER_ID] +
+            f"\nPlanner notes:\n{action}\n"
+            "Now provide the final arithmetic expression inside <answer></answer>."
+        )
+        return {
+            "current_agent": SOLVER_ID,
+            "next_observations": {SOLVER_ID: solver_state},
+            "rewards": {PLANNER_ID: 0.0, SOLVER_ID: 0.0},
+            "done": False,
+            "done_agents": [PLANNER_ID],
+            "shared_info": shared_info,
+            "extra_info": extra_info
+        }
+
+    sample_obj = kwargs.get("sample")
+    raw_sample = sample_obj.sample if sample_obj is not None else {}
+    reward = _compute_countdown_reward(
+        {
+            **raw_sample,
+            "extra_info": extra_info
+        },
+        action
+    )
+    return {
+        "rewards": {
+            PLANNER_ID: reward,
+            SOLVER_ID: reward
+        },
+        "scores": {
+            PLANNER_ID: reward,
+            SOLVER_ID: reward
+        },
+        "done": True,
+        "done_agents": [PLANNER_ID, SOLVER_ID],
+        "shared_info": {
+            **shared_info,
+            "global_reward": reward
+        },
+        "extra_info": extra_info
+    }

--- a/examples/multi_agent_countdown_reinforce.sh
+++ b/examples/multi_agent_countdown_reinforce.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cluster-friendly one-click launch script for the phase-1 shared-policy
+# multi-agent countdown example. Override any variable below via env vars.
+
+NPROC_PER_NODE="${NPROC_PER_NODE:-4}"
+NNODES="${NNODES:-1}"
+NODE_RANK="${NODE_RANK:-0}"
+MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+MASTER_PORT="${MASTER_PORT:-29500}"
+
+TRAIN_PATH="${TRAIN_PATH:-train@Chenmien/Countdown}"
+TEST_PATH="${TEST_PATH:-test@Chenmien/Countdown}"
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen2.5-3B-Instruct}"
+
+PROMPTS_PER_ROLLOUT="${PROMPTS_PER_ROLLOUT:-128}"
+RESPONSES_PER_PROMPT="${RESPONSES_PER_PROMPT:-4}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-1024}"
+MAX_LENGTH_PER_DEVICE="${MAX_LENGTH_PER_DEVICE:-8192}"
+
+REWARD_MODE="${REWARD_MODE:-team}"
+AGENT_ORDER="${AGENT_ORDER:-env_driven}"
+TOTAL_STEPS="${TOTAL_STEPS:-512}"
+TEST_FREQ="${TEST_FREQ:-8}"
+SAVE_FREQ="${SAVE_FREQ:-32}"
+PROJECT="${PROJECT:-Countdown}"
+EXPERIMENT_NAME="${EXPERIMENT_NAME:-qwen2.5-3b_multi_agent_reinforce}"
+STOP_TOKENS="${STOP_TOKENS:-['</answer>']}"
+
+torchrun \
+    --nnodes="${NNODES}" \
+    --node_rank="${NODE_RANK}" \
+    --nproc_per_node="${NPROC_PER_NODE}" \
+    --master_addr="${MASTER_ADDR}" \
+    --master_port="${MASTER_PORT}" \
+    -m RL2.trainer.ppo \
+    rollout.train.path="${TRAIN_PATH}" \
+    rollout.train.prompts_per_rollout="${PROMPTS_PER_ROLLOUT}" \
+    rollout.train.responses_per_prompt="${RESPONSES_PER_PROMPT}" \
+    rollout.train.sampling_params.max_new_tokens="${MAX_NEW_TOKENS}" \
+    "rollout.train.sampling_params.stop=${STOP_TOKENS}" \
+    rollout.test.path="${TEST_PATH}" \
+    rollout.env_path=envs/multi_agent_countdown.py \
+    rollout.multi_agent.enabled=true \
+    rollout.multi_agent.shared_policy=true \
+    rollout.multi_agent.reward_mode="${REWARD_MODE}" \
+    rollout.multi_agent.agent_order="${AGENT_ORDER}" \
+    actor.model_name="${MODEL_NAME}" \
+    actor.max_length_per_device="${MAX_LENGTH_PER_DEVICE}" \
+    trainer.project="${PROJECT}" \
+    trainer.experiment_name="${EXPERIMENT_NAME}" \
+    trainer.total_steps="${TOTAL_STEPS}" \
+    trainer.test_freq="${TEST_FREQ}" \
+    trainer.save_freq="${SAVE_FREQ}"

--- a/examples/multi_agent_countdown_reinforce.slurm
+++ b/examples/multi_agent_countdown_reinforce.slurm
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=rl2-ma-countdown
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:8
+#SBATCH --cpus-per-task=16
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+set -euo pipefail
+
+# Submit example:
+# sbatch \
+#   --nodes=2 \
+#   --gres=gpu:8 \
+#   --job-name=rl2-ma-countdown \
+#   examples/multi_agent_countdown_reinforce.slurm
+#
+# Override training settings without editing the file:
+# sbatch --export=ALL,TRAIN_PATH=/path/train.jsonl,TEST_PATH=/path/test.jsonl,MODEL_NAME=Qwen/Qwen2.5-7B-Instruct examples/multi_agent_countdown_reinforce.slurm
+
+ROOT_DIR="${ROOT_DIR:-$SLURM_SUBMIT_DIR}"
+cd "${ROOT_DIR}"
+
+mkdir -p logs
+
+MASTER_ADDR="${MASTER_ADDR:-$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)}"
+MASTER_PORT="${MASTER_PORT:-29500}"
+NNODES="${NNODES:-$SLURM_NNODES}"
+NPROC_PER_NODE="${NPROC_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}"
+
+TRAIN_PATH="${TRAIN_PATH:-train@Chenmien/Countdown}"
+TEST_PATH="${TEST_PATH:-test@Chenmien/Countdown}"
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen2.5-3B-Instruct}"
+EXPERIMENT_NAME="${EXPERIMENT_NAME:-qwen2.5-3b_multi_agent_countdown}"
+PROJECT="${PROJECT:-Countdown}"
+
+echo "MASTER_ADDR=${MASTER_ADDR}"
+echo "MASTER_PORT=${MASTER_PORT}"
+echo "NNODES=${NNODES}"
+echo "NPROC_PER_NODE=${NPROC_PER_NODE}"
+echo "TRAIN_PATH=${TRAIN_PATH}"
+echo "TEST_PATH=${TEST_PATH}"
+echo "MODEL_NAME=${MODEL_NAME}"
+echo "EXPERIMENT_NAME=${EXPERIMENT_NAME}"
+
+srun --nodes="${NNODES}" --ntasks="${NNODES}" --ntasks-per-node=1 \
+    bash -lc '
+        set -euo pipefail
+        export NODE_RANK="${SLURM_NODEID}"
+        export MASTER_ADDR="'"${MASTER_ADDR}"'"
+        export MASTER_PORT="'"${MASTER_PORT}"'"
+        export NNODES="'"${NNODES}"'"
+        export NPROC_PER_NODE="'"${NPROC_PER_NODE}"'"
+        export TRAIN_PATH="'"${TRAIN_PATH}"'"
+        export TEST_PATH="'"${TEST_PATH}"'"
+        export MODEL_NAME="'"${MODEL_NAME}"'"
+        export EXPERIMENT_NAME="'"${EXPERIMENT_NAME}"'"
+        export PROJECT="'"${PROJECT}"'"
+        bash examples/multi_agent_countdown_reinforce.sh
+    '


### PR DESCRIPTION
## Summary
- add a compatible multi-agent environment protocol that supports `reset`/`step` while keeping existing custom rollout entrypoints usable
- flatten per-agent trajectories back into PPO-ready samples and extend advantage computation/configuration for shared-policy multi-agent training
- add a multi-agent countdown environment plus launch scripts and README guidance for direct cluster submission